### PR TITLE
change attribute to a supported type

### DIFF
--- a/Rachio Controller
+++ b/Rachio Controller
@@ -71,7 +71,7 @@ metadata {
         attribute "nextEventType", "string"
         attribute "nextEventWeatherIntelligence", "string"
         attribute "nextEventThresholdInfo", "string"
-        attribute "rainSensorTripped", "boolean"
+        attribute "rainSensorTripped", "string"
         
         attribute "monthlyMinutesUsed", "number"
         attribute "monthlyMinutesSaved", "number"


### PR DESCRIPTION
Boolean is not a valid attribute type according to:
https://docs.hubitat.com/index.php?title=Attribute_Object

This will cause applications to have problems when they query attributes and their type